### PR TITLE
Fix an incorrect call to super() constructor

### DIFF
--- a/switchbot/devices.py
+++ b/switchbot/devices.py
@@ -91,7 +91,7 @@ class Curtain(Device):
     device_type_for = 'Curtain'
 
     def __init__(self, client: SwitchBotClient, id: str, **extra):
-        super().__init__(self, id, **extra)
+        super().__init__(self, client, id, **extra)
 
         self.curtain_ids: List[str] = extra.get('curtain_devices_ids')
         self.calibrated: bool = extra.get('calibrate')


### PR DESCRIPTION
The `Curtain` device class was not passing the `client` when calling its parent constructor, resulting in broken calls to its `status()` and `command()` methods, e.g.:

```
>>> curtain.status()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/switchbot/devices.py", line 54, in status
    response = self.client.get(f'devices/{self.id}/status')
AttributeError: 'Curtain' object has no attribute 'get'

>>> curtain.command('turn_on')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/switchbot/devices.py", line 66, in command
    self.client.post(f'devices/{self.id}/commands', json=payload)
AttributeError: 'Curtain' object has no attribute 'post'
```